### PR TITLE
Add more cypress testing and remove updateCurrentPoster function.

### DIFF
--- a/cypress/e2e/home-view.cy.js
+++ b/cypress/e2e/home-view.cy.js
@@ -31,4 +31,12 @@ describe('Rancid Home View', () => {
     .get('.release-date').contains('Released: November 11th, 2022')
     .get('.rating').contains('Rating: 1.0')
   })
+  it('when I click on the x button, i am directed back to the home page', () => {
+    cy.intercept("GET", "https://rancid-tomatillos.herokuapp.com/api/v2/movies", {
+      fixture: "../fixtures/movies"
+    })
+    .get(`.posters-wrapper img#${829799}`).click()
+    .get('.x-btn').click()
+    .get('h1').should('have.text', 'Rancid Tomatillos')
+  })
 })

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -2,13 +2,12 @@ import Header from "../Header/Header"
 import Poster from "../Poster/Poster"
 import { PropTypes } from 'prop-types'
 
-function Home({ movies, updateCurrentPoster }) {
+function Home({ movies }) {
   return (
     <>
       <Header />
       <Poster
         movies={movies}
-        updateCurrentPoster={updateCurrentPoster}
       />
     </>
   )
@@ -18,6 +17,5 @@ export default Home
 
 Home.propTypes = {
   movies: PropTypes.array.isRequired,
-  updateCurrentPoster: PropTypes.func.isRequired,
 }
 

--- a/src/components/MovieDetails/MovieDetails.css
+++ b/src/components/MovieDetails/MovieDetails.css
@@ -74,7 +74,7 @@
 
 .x-btn {
   color: white;
-
+}
 @media (max-width:480px) {
   .movie-poster {
     width: 75%;


### PR DESCRIPTION
# Description

This PR introduces more Cypress testing for the close button to redirect the user back to he home page. Also deleting the updateCurrentPoster function, since we don't use that function anymore, with the addition of Router.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
      
# How Has This Been Tested?
Cypress

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] I have tested my code to prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
